### PR TITLE
Remove duplicate mentions of paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@
 - \[[arxiv](https://arxiv.org/abs/2404.14741)\] Generate-on-Graph: Treat LLM as both Agent and KG in Incomplete Knowledge Graph Question Answering. `2024.04`
 - \[[arxiv](https://arxiv.org/abs/2404.16130)\] From Local to Global: A Graph RAG Approach to Query-Focused Summarization. `2024.04`
 - \[[arxiv](https://arxiv.org/abs/2312.15883)\] HyKGE: A Hypothesis Knowledge Graph Enhanced Framework for Accurate and Reliable Medical LLMs Responses. `2024.04`
-- \[[arxiv](https://arxiv.org/abs/2404.00942)\] Evaluating the Factuality of Large Language Models using Large-Scale Knowledge Graphs. `2024.04`
-- \[[arxiv](https://arxiv.org/abs/2404.00942)\] Evaluating the Factuality of Large Language Models using Large-Scale Knowledge Graphs. `2024.04`
 - \[[arxiv](https://arxiv.org/abs/2403.14950)\] KnowLA: Enhancing Parameter-efficient Finetuning with Knowledgeable Adaptation. `2024.03`
 - \[[LREC-COLING 2024](https://arxiv.org/abs/2403.17532)\] KC-GenRe: A Knowledge-constrained Generative Re-ranking Method Based on Large Language Models for Knowledge Graph Completion. `2024.03`
 - \[[arxiv](https://arxiv.org/abs/2403.14253)\] K-Act2Emo: Korean Commonsense Knowledge Graph for Indirect Emotional Expression. `2024.03`

--- a/README.md
+++ b/README.md
@@ -240,7 +240,6 @@
 - \[[arxiv](https://arxiv.org/abs/2310.08279)\] CP-KGC: Constrained-Prompt Knowledge Graph Completion with Large Language Models. `2023.10`
 - \[[arxiv](https://arxiv.org/abs/2310.07170)\] PHALM: Building a Knowledge Graph from Scratch by Prompting Humans and a Language Model. `2023.10`
 - \[[arxiv](https://arxiv.org/abs/2310.03269)\] InstructProtein: Aligning Human and Protein Language via Knowledge Instruction. `2023.10`
-- \[[arxiv](https://arxiv.org/abs/2310.02166)\] Large Language Models Meet Knowledge Graphs to Answer Factoid Questions. `2023.10`
 - \[[arxiv](https://arxiv.org/abs/2310.01290)\] Knowledge Crosswords: Geometric Reasoning over Structured Knowledge with Large Language Models. `2023.10`
 - \[[ICLR 2024](https://arxiv.org/abs/2310.01061)\] Reasoning on Graphs: Faithful and Interpretable Large Language Model Reasoning. `2023.10` \[[Repo](https://github.com/RManLuo/reasoning-on-graphs)\]
 - \[[arxiv](https://arxiv.org/abs/2310.00299)\] RelBERT: Embedding Relations with Language Models. `2023.10`


### PR DESCRIPTION
The paper `Evaluating the Factuality of Large Language Models using Large-Scale Knowledge Graphs` was mentioned 3 times. At lines 120, 126 and 128

The paper ` Large Language Models Meet Knowledge Graphs to Answer Factoid Questions` was mentioned twice at line 225 and 245