### PR TITLE
Add KG4ESG: The ESG Knowledge Graph Atlas (LLM × KG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 
 
 ### Method
+- \[[Preprints](https://www.preprints.org/manuscript/202602.1970)\] KG4ESG: The ESG Knowledge Graph Atlas. `2026.02`
 - \[[arxiv](https://arxiv.org/abs/2502.10453)\] Linking Cryptoasset Attribution Tags to Knowledge Graph Entities: An LLM-based Approach. `2025.2`
 - \[[arxiv](https://arxiv.org/abs/2502.05478)\] OntoTune: Ontology-Driven Self-training for Aligning Large Language Models. `2025.2`
 - \[[EMNLP 2024 findings](https://aclanthology.org/2024.findings-emnlp.524/)\] Question-guided Knowledge Graph Re-scoring and Injection for Knowledge Graph Question Answering. `2024.11`


### PR DESCRIPTION
Adds **KG4ESG: The ESG Knowledge Graph Atlas** to **Method** (top, by date).

KG4ESG integrates **knowledge graphs and LLMs**: an LLM-empowered KG atlas for the Environmental, Social, and Governance (ESG) domain, integrating ESG standards, frameworks, and entities.

Link: https://www.preprints.org/manuscript/202602.1970 (preprint, 2026.02)

Follows the entry format `- \[[venue](url)\] Title. \`YYYY.MM\``.