### PR TITLE
Add paper: SSKG Hub — Expert-Guided Platform for LLM-Empowered Sustainability Standards KGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 ### Method
 - \[[arxiv](https://arxiv.org/abs/2502.10453)\] Linking Cryptoasset Attribution Tags to Knowledge Graph Entities: An LLM-based Approach. `2025.2`
 - \[[arxiv](https://arxiv.org/abs/2502.05478)\] OntoTune: Ontology-Driven Self-training for Aligning Large Language Models. `2025.2`
+- \[[arxiv](https://arxiv.org/abs/2603.00669)\] SSKG Hub: An Expert-Guided Platform for LLM-Empowered Sustainability Standards Knowledge Graphs. `2026.02`
 - \[[EMNLP 2024 findings](https://aclanthology.org/2024.findings-emnlp.524/)\] Question-guided Knowledge Graph Re-scoring and Injection for Knowledge Graph Question Answering. `2024.11`
 - \[[EMNLP 2024 findings](https://arxiv.org/abs/2407.11417)\] SPINACH: SPARQL-Based Information Navigation for Challenging Real-World Questions. `2024.11`
 - \[[arxiv](https://arxiv.org/pdf/2410.18415)\] Decoding on Graphs: Faithful and Sound Reasoning on Knowledge Graphs through Generation of Well-Formed Chains. `2024.10`


### PR DESCRIPTION
Adds **"SSKG Hub: An Expert-Guided Platform for LLM-Empowered Sustainability Standards Knowledge Graphs"** (He et al., arXiv 2026) to **Method**.

A KG+LLM integration system: LLM extraction turns sustainability disclosure standards (GRI, SASB, TCFD, IFRS S2) into provenance-linked Draft KGs that domain experts review and certify (role-based governance, Neo4j). Live platform: https://www.sskg-hub.com/

Link: https://arxiv.org/abs/2603.00669

Follows the `- \[[venue](url)\] Title. \`YYYY.MM\`` format; anchored to avoid overlap with my open PR #51 (different paper/anchor — both merge cleanly). Disclosure: I am an author.